### PR TITLE
Update mongoperf.txt

### DIFF
--- a/source/reference/program/mongoperf.txt
+++ b/source/reference/program/mongoperf.txt
@@ -63,6 +63,7 @@ Configuration Fields
    *Default:* 1 megabyte (i.e. 1024\ :sup:`2` bytes)
 
    Test file size.
+   Note that :program:`mongoperf` always creates the test file in current directory.
 
 .. setting:: mongoperf.sleepMicros
 


### PR DESCRIPTION
Fix this ticket: https://jira.mongodb.org/browse/SERVER-12130

Explain where does `mongoperf` put its test file.
